### PR TITLE
BoomTables Formatting Fix + PIG-1082 

### DIFF
--- a/src/app/boom/BoomOutput.ts
+++ b/src/app/boom/BoomOutput.ts
@@ -53,7 +53,7 @@ BoomOutput.prototype.getDataAsHTML = function(data: IBoomTable, sorting_props): 
   }
   _.each(data.output, o => {
     if (o.map(item => item.hidden.toString()).indexOf('false') > -1) {
-      output.body += '<tr>';
+      output.body += '<tr style="white-space: nowrap">';
       if (this.hide_first_column !== true) {
         let raw_rowName = _.first(o.map(item => item.row_name_raw));
         output.body += `

--- a/src/module.ts
+++ b/src/module.ts
@@ -166,7 +166,7 @@ GrafanaBoomTableCtrl.prototype.render = function () {
     let boom_output = new BoomOutput(renderingOptions);
     this.outdata = {
       cols_found: boomtabledata.cols_found.map(col => {
-        return this.$sce.trustAsHtml(col);
+        return this.$sce.trustAsHtml(col.replace('&#10240', ''));
       }),
     };
     let renderingdata: IBoomHTML = boom_output.getDataAsHTML(boomtabledata, this.panel.sorting_props);

--- a/src/partials/module.html
+++ b/src/partials/module.html
@@ -26,10 +26,10 @@
                 <tr>
                     <th data-ng-if="ctrl.panel.hide_first_column !== true" style="padding:4px;text-align:{{ctrl.panel.text_alignment_firstcolumn}}" ng-bind="ctrl.panel.default_title_for_rows">
                     </th>
-                    <th ng-repeat="col in ctrl.outdata.cols_found track by $index" ng-click="ctrl.sortByHeader($index)" style="padding:4px;text-align:{{ctrl.panel.text_alignment_header}}">
-                        <span ng-bind-html="col"></span>
+                    <th ng-repeat="col in ctrl.outdata.cols_found track by $index" ng-click="ctrl.sortByHeader($index)" style="white-space: nowrap;padding:4px;text-align:{{ctrl.panel.text_alignment_header}}">
                         <i class="fa fa-arrow-up sortarrows" data-ng-if="ctrl.panel.sorting_props.col_index === $index && ctrl.panel.sorting_props.direction === 'asc'"></i>
                         <i class="fa fa-arrow-down sortarrows" data-ng-if="ctrl.panel.sorting_props.col_index === $index && ctrl.panel.sorting_props.direction === 'desc'"></i>
+                        <span ng-bind-html="col" style="white-space: normal;"></span>
                     </th>
                 </tr>
             </thead>


### PR DESCRIPTION
Fixes formatting issues related to recent species additions to the simulator. Additionally this indirectly corresponds to 

> 
>   PIG-1082
>   
>   https://picarro.atlassian.net/browse/PIG-1082
> 
>   Species with long names not able to display current measurements in a proper way

as these species with long names crowd the tables substantially. The fix is accomplished by removing whitespace (meant to trick boomtables into the correct ordering) after it is done sorting and changing some of the styling of the tables.