### PR TITLE
PIG-1092: Reduce Table Header Crowdedness  

### DIFF
--- a/src/partials/module.html
+++ b/src/partials/module.html
@@ -26,7 +26,7 @@
                 <tr>
                     <th data-ng-if="ctrl.panel.hide_first_column !== true" style="padding:4px;text-align:{{ctrl.panel.text_alignment_firstcolumn}}" ng-bind="ctrl.panel.default_title_for_rows">
                     </th>
-                    <th ng-repeat="col in ctrl.outdata.cols_found track by $index" ng-click="ctrl.sortByHeader($index)" style="white-space: nowrap;padding:4px;text-align:{{ctrl.panel.text_alignment_header}}">
+                    <th ng-repeat="col in ctrl.outdata.cols_found track by $index" ng-click="ctrl.sortByHeader($index)" style="white-space: nowrap;padding:5px;text-align:{{ctrl.panel.text_alignment_header}}">
                         <i class="fa fa-arrow-up sortarrows" data-ng-if="ctrl.panel.sorting_props.col_index === $index && ctrl.panel.sorting_props.direction === 'asc'"></i>
                         <i class="fa fa-arrow-down sortarrows" data-ng-if="ctrl.panel.sorting_props.col_index === $index && ctrl.panel.sorting_props.direction === 'desc'"></i>
                         <span ng-bind-html="col" style="white-space: normal;"></span>


### PR DESCRIPTION
Reduces table header Crowdedness by adding a pixel to the padding.

This corresponds to 

> 
> PIG-1092
> 
> https://picarro.atlassian.net/browse/PIG-1092
> 
> We will need to put Min. Acetic Acid and Max. Acetic Acid header to 2 lines on Home screen